### PR TITLE
Add retry logic to ingestion modules

### DIFF
--- a/geminiBOT712/src/data_ingestion/base_ingester.py
+++ b/geminiBOT712/src/data_ingestion/base_ingester.py
@@ -38,6 +38,26 @@ class BaseIngester(ABC):
         except Exception as e:
             logger.error(f"Failed to publish to Redis channel '{channel}': {e}")
 
+    async def request_with_retries(self, method: str, url: str, *, retries: int = 3, backoff: float = 2.0, **kwargs) -> httpx.Response:
+        """Makes an HTTP request with exponential backoff retries."""
+        delay = 1.0
+        for attempt in range(1, retries + 1):
+            try:
+                response = await self.client.request(method, url, **kwargs)
+                response.raise_for_status()
+                return response
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                logger.warning(
+                    f"Attempt {attempt} failed for {url}: {e}", exc_info=True
+                )
+                if attempt == retries:
+                    logger.error(
+                        f"Exceeded {retries} retries for {url}", exc_info=True
+                    )
+                    raise
+                await asyncio.sleep(delay)
+                delay *= backoff
+
     async def run(self, interval_seconds: int):
         """
         Runs the data fetching process at a specified interval.
@@ -93,8 +113,7 @@ class UnusualWhalesIngester(BaseIngester):
         params = {'limit': 50} # Limit the number of trades per fetch
 
         try:
-            response = await self.client.get(url, headers=headers, params=params)
-            response.raise_for_status()
+            response = await self.request_with_retries("GET", url, headers=headers, params=params)
             flow_records = response.json().get('data', [])
             
             if not flow_records:

--- a/geminiBOT712/src/data_ingestion/bigshort.py
+++ b/geminiBOT712/src/data_ingestion/bigshort.py
@@ -34,8 +34,7 @@ class BigShortIngester(BaseIngester):
         params = {"token": self.api_key}
 
         try:
-            response = await self.client.get(url, params=params)
-            response.raise_for_status()
+            response = await self.request_with_retries("GET", url, params=params)
             flow_data = response.json().get('data', [])
 
             if not flow_data:
@@ -94,8 +93,7 @@ class YahooFinanceIngester(BaseIngester):
         }
 
         try:
-            response = await self.client.get(url, params=params, headers=headers)
-            response.raise_for_status()
+            response = await self.request_with_retries("GET", url, params=params, headers=headers)
             quote_response = response.json().get('quoteResponse', {})
             results = quote_response.get('result', [])
 

--- a/geminiBOT712/src/data_ingestion/news_scraper.py
+++ b/geminiBOT712/src/data_ingestion/news_scraper.py
@@ -9,57 +9,80 @@ import json
 
 logger = get_logger(__name__)
 
+
 class FinancialNewsScraper(BaseIngester):
     """
     Scrapes the headlines from a major financial news site's homepage.
     This provides a free, real-time source of news for sentiment analysis.
     """
+
     def __init__(self, news_url: str = "https://www.marketwatch.com/"):
         super().__init__()
         self.news_url = news_url
-        self.seen_headlines = set() # Avoid processing duplicate headlines
+        self.seen_headlines = set()  # Avoid processing duplicate headlines
 
     async def fetch_data(self):
         """Scrapes the news website for the latest headlines."""
         headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
         }
         try:
-            async with httpx.AsyncClient(headers=headers, timeout=30.0, follow_redirects=True) as client:
-                response = await client.get(self.news_url)
-                response.raise_for_status()
-                
-                soup = BeautifulSoup(response.text, 'html.parser')
-                
-                # The specific tags and classes will change depending on the site.
-                # This is an example for MarketWatch and needs to be maintained.
-                headlines = soup.find_all('h3', class_='article__headline')
-                
-                new_headlines_found = 0
-                for headline in headlines:
-                    title = headline.get_text(strip=True)
-                    link_tag = headline.find('a', class_='link')
-                    link = link_tag['href'] if link_tag else None
+            delay = 1.0
+            for attempt in range(1, 4):
+                try:
+                    async with httpx.AsyncClient(
+                        headers=headers, timeout=30.0, follow_redirects=True
+                    ) as client:
+                        response = await client.get(self.news_url)
+                        response.raise_for_status()
+                    break
+                except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                    logger.warning(
+                        f"Attempt {attempt} failed fetching news: {e}", exc_info=True
+                    )
+                    if attempt == 3:
+                        raise
+                    await asyncio.sleep(delay)
+                    delay *= 2
 
-                    if title and link and title not in self.seen_headlines:
-                        self.seen_headlines.add(title)
-                        new_headlines_found += 1
-                        
-                        # Extract potential symbols from the headline text
-                        symbols = [word.replace('$', '') for word in title.split() if word.startswith('$')]
+            soup = BeautifulSoup(response.text, "html.parser")
 
-                        news_data = {
-                            "source": "MarketWatch Scraper",
-                            "title": title,
-                            "link": link,
-                            "symbols": symbols # List of mentioned symbols
-                        }
-                        # Publish to the same channel as the RSS ingester
-                        await self.publish_to_redis('news_articles', news_data)
+            # The specific tags and classes will change depending on the site.
+            # This is an example for MarketWatch and needs to be maintained.
+            headlines = soup.find_all("h3", class_="article__headline")
 
-                if new_headlines_found > 0:
-                    logger.info(f"Scraped {new_headlines_found} new headlines from {self.news_url}")
+            new_headlines_found = 0
+            for headline in headlines:
+                title = headline.get_text(strip=True)
+                link_tag = headline.find("a", class_="link")
+                link = link_tag["href"] if link_tag else None
+
+                if title and link and title not in self.seen_headlines:
+                    self.seen_headlines.add(title)
+                    new_headlines_found += 1
+
+                    # Extract potential symbols from the headline text
+                    symbols = [
+                        word.replace("$", "")
+                        for word in title.split()
+                        if word.startswith("$")
+                    ]
+
+                    news_data = {
+                        "source": "MarketWatch Scraper",
+                        "title": title,
+                        "link": link,
+                        "symbols": symbols,
+                    }
+                    await self.publish_to_redis("news_articles", news_data)
+
+            if new_headlines_found > 0:
+                logger.info(
+                    f"Scraped {new_headlines_found} new headlines from {self.news_url}"
+                )
 
         except Exception as e:
-            logger.error(f"Error scraping financial news from {self.news_url}: {e}", exc_info=True)
-
+            logger.error(
+                f"Error scraping financial news from {self.news_url}: {e}",
+                exc_info=True,
+            )


### PR DESCRIPTION
## Summary
- add `request_with_retries` helper in `BaseIngester`
- use exponential backoff retries in `fetch_data` for API modules
- log and propagate failures when retries are exhausted

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6872c3ba9a34832b91dea6791e19e3c7