### PR TITLE
Improve risk management and analytics

### DIFF
--- a/geminiBOT712/src/risk_management/volatility_manager.py
+++ b/geminiBOT712/src/risk_management/volatility_manager.py
@@ -60,5 +60,18 @@ class VolatilityManager:
             stop_loss = entry_price - (atr * multiplier)
         else: # BEARISH
             stop_loss = entry_price + (atr * multiplier)
-            
+
         return stop_loss
+
+    def trailing_stop(self, current_price: float, existing_stop: float, direction: str,
+                       atr: float, multiplier: float = 2.0) -> float:
+        """Calculates a new stop loss that trails the current price."""
+        if atr <= 0:
+            return existing_stop
+
+        if direction == 'BULLISH':
+            new_stop = max(existing_stop, current_price - (atr * multiplier))
+        else:  # BEARISH
+            new_stop = min(existing_stop, current_price + (atr * multiplier))
+
+        return new_stop

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,15 @@
+import sys, os
+import pandas as pd
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "geminiBOT712"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "geminiBOT712", "src"))
+
+from src.backtesting.performance_analyzer import PerformanceAnalyzer
+
+
+def test_metrics_include_sortino_and_cagr():
+    trades = [{"pnl": 10}, {"pnl": -5}]
+    equity = pd.Series([100, 110, 105])
+    analyzer = PerformanceAnalyzer(trades, equity)
+    metrics = analyzer.calculate_metrics()
+    assert "Sortino Ratio" in metrics
+    assert "CAGR" in metrics

--- a/tests/test_volatility.py
+++ b/tests/test_volatility.py
@@ -1,0 +1,14 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "geminiBOT712"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "geminiBOT712", "src"))
+
+from src.risk_management.volatility_manager import VolatilityManager
+
+
+def test_trailing_stop_moves():
+    vm = VolatilityManager()
+    stop = vm.trailing_stop(current_price=105, existing_stop=100, direction="BULLISH", atr=2, multiplier=1)
+    assert stop == 103
+    # Should not lower the stop if price falls
+    stop2 = vm.trailing_stop(current_price=101, existing_stop=stop, direction="BULLISH", atr=2, multiplier=1)
+    assert stop2 == 103


### PR DESCRIPTION
## Summary
- add trailing stop capability in `VolatilityManager`
- update portfolio monitor to use dynamic trailing stops
- capture Sortino ratio and CAGR in performance analyzer
- use concurrent fetching in GoogleTrends ingester
- add database helpers for closing trades and updating stops
- test new analytics and risk logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873d2aebd08832b9acb9b9ef60e3323